### PR TITLE
spd5118: Don't declare I2C_CLASS_SPD

### DIFF
--- a/spd5118.c
+++ b/spd5118.c
@@ -535,7 +535,7 @@ MODULE_DEVICE_TABLE(of, spd5118_of_ids);
 #endif
 
 static struct i2c_driver spd5118_driver = {
-	.class		= I2C_CLASS_SPD | I2C_CLASS_HWMON,
+	.class		= I2C_CLASS_HWMON,
 	.driver = {
 		.name	= "spd5118",
 		.dev_groups = spd5118_groups,


### PR DESCRIPTION
This has been removed since 6.10

https://github.com/torvalds/linux/commit/e61bcf42d290e73025bab38e0e55a5586c2d8ad5